### PR TITLE
fix wait for container

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,10 @@ use anyhow::{Error, Ok};
 use bollard::{container::LogsOptions, Docker};
 use core::time::Duration;
 use futures::stream::StreamExt;
-use chrono::DateTime;
 use std::{
     env,
     io::{stdout, Write},
-    ops::{Add},
+    ops::Add,
 };
 
 mod undertaker;


### PR DESCRIPTION
last_word didn't wait for the container properly. If the container started the process crashed. But if the container was already up and running logs were consumed correctly.